### PR TITLE
chore: change environment variables strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 # Database
-DATABASE_URL="postgresql://docker:docker@localhost:5432/app"
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_USER=docker
+DATABASE_PASS=docker
+DATABASE_NAME=app
+
+DATABASE_URL="postgresql://${DATABASE_USER}:${DATABASE_PASS}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}"

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,2 +1,8 @@
 # Database
-DATABASE_URL="postgresql://docker:docker@localhost:5432/app"
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_USER=docker
+DATABASE_PASS=docker
+DATABASE_NAME=app
+
+DATABASE_URL="postgresql://${DATABASE_USER}:${DATABASE_PASS}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "apollo-server-plugin-base": "3.2.0",
     "class-transformer": "0.4.0",
     "class-validator": "0.13.1",
+    "dotenv-expand": "5.1.0",
     "faker": "^5.5.3",
     "graphql": "15.5.3",
     "graphql-query-complexity": "0.9.0",

--- a/prisma/prisma-test-environment.ts
+++ b/prisma/prisma-test-environment.ts
@@ -1,12 +1,13 @@
 import type { Config } from '@jest/types';
 import { exec } from 'child_process';
 import dotenv from 'dotenv';
+import dotenvExpand from 'dotenv-expand';
 import NodeEnvironment from 'jest-environment-node';
 import { Client } from 'pg';
 import util from 'util';
 import { v4 as uuid } from 'uuid';
 
-dotenv.config({ path: '.env.testing' });
+dotenvExpand(dotenv.config({ path: '.env.testing' }));
 
 const execSync = util.promisify(exec);
 
@@ -19,8 +20,14 @@ export default class PrismaTestEnvironment extends NodeEnvironment {
   constructor(config: Config.ProjectConfig) {
     super(config);
 
+    const dbUser = process.env.DATABASE_USER;
+    const dbPass = process.env.DATABASE_PASS;
+    const dbHost = process.env.DATABASE_HOST;
+    const dbPort = process.env.DATABASE_PORT;
+    const dbName = process.env.DATABASE_NAME;
+
     this.schema = `test_${uuid()}`;
-    this.connectionString = `${process.env.DATABASE_URL}?schema=${this.schema}`;
+    this.connectionString = `postgresql://${dbUser}:${dbPass}@${dbHost}:${dbPort}/${dbName}?schema=${this.schema}`;
   }
 
   async setup() {


### PR DESCRIPTION
This PR changes environment variables strategy to prevent db error when running e2e tests.

The error in question is: `db error: ERROR: identifier too long`
