### PR TITLE
chore: Enable shutdown listeners

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,8 @@ async function bootstrap() {
   app.useLogger(LoggerServiceInstance);
   app.useGlobalInterceptors(new LoggerErrorInterceptor());
   app.useGlobalPipes(new ValidationPipe());
+  
+  app.enableShutdownHooks();
 
   app.listen(3333).then(() => {
     lightship.signalReady();


### PR DESCRIPTION
Enable hooks called in the terminating phase, this is used with Kubernetes to manage containers' lifecycles.